### PR TITLE
ci: Set correct distro when packaging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,7 @@ jobs:
         nfpm_file: "nfpm.yaml.${{ matrix.distro }}"
       env:
         COMMITS: ${{ steps.build.outputs.commits }}
+        DISTRO: ${{ matrix.distro }}
 
     - name: Upload build artifacts to GitHub
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This sets `DISTRO` env variable in package step that will correct package versions.

Signed-off-by: Arturs Janis Petersons <arturs@unikraft.io>